### PR TITLE
Proper sense resistor for nitehawk36

### DIFF
--- a/Firmware/printer_data/config/printer.cfg
+++ b/Firmware/printer_data/config/printer.cfg
@@ -365,6 +365,10 @@ pressure_advance_smooth_time: 0.040 # this can be calibrated later
 [tmc2209 extruder]
 uart_pin: thb:E_UART
 run_current: 0.650
+######################
+#	Uncomment for NH36 #
+######################
+#sense_resistor: .100
 
 ##############
 # Bed Heater #


### PR DESCRIPTION
Per LDO docs, the NH36 uses a 100ohm resistor in its 2209 driver. Klipper will default to 0.110, Kalico will error with this missing. This adds a note similar to the extruder section to the stepper for the NH36. Looking at the repository history, this appears to have been the config from the start so it should apply to all generations of the board.

https://github.com/MotorDynamicsLab/Nitehawk-36/blob/master/Configs/nitehawk-36.cfg#L51

<img width="2760" height="267" alt="image" src="https://github.com/user-attachments/assets/0f5b861d-0af9-4d9f-91b9-c7bd700e4caf" />
